### PR TITLE
fixed composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "alchemyai/alchemyapi_php",
+    "name": "alchemyapi/alchemyapi_php",
     "type": "sdk",
     "description": "A software development kit (sdk) for AlchemyAPI using PHP",
     "keywords": ["alchemyapi","alchemyai","php","ai","sdk"],


### PR DESCRIPTION
Was unable to install package because of typo in composer package name. 
