### PR TITLE
updated composer to support classmap autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,8 @@
             "homepage": "http://www.alchemyapi.com/",
             "role": "Developer"
         }
-    ]
+    ],
+    "autoload": {
+        "classmap": ["alchemyapi.php"]
+     }
 }


### PR DESCRIPTION
Adding classmap autoload support to composer allows developers to access the AlchemyAPI class without explicitly requiring the file.  The autoloading support only applies to users including the package via composer and will not require any code changes for existing users.  Autoloading only runs when the AlchemyAPI class is called _and_ has not already been explicitly included.

Supporting autoload means easier deployment for systems where vendor filepaths can vary from server to server.  