### PR TITLE
Prevent warning on closing an failed fopen

### DIFF
--- a/alchemyapi.php
+++ b/alchemyapi.php
@@ -740,7 +740,11 @@ class AlchemyAPI {
 		try {
 			$fp = @fopen($url, 'rb',false, stream_context_create($header));
 			$response = @stream_get_contents($fp);
-			fclose($fp);
+			
+			if($fp) {
+				fclose($fp);
+			}
+			
 			return json_decode($response, true);
 		} catch (Exception $e) {
 			return array('status'=>'ERROR', 'statusInfo'=>'Network error');


### PR DESCRIPTION
If fopen fails (such as the network being down or an invalid URL) then $fp is set to null via the suppression (not ideal). fclose needs to at least check for that.
